### PR TITLE
Minor changes to synchronize with source

### DIFF
--- a/drivers/cisco/cisco-fpga-bmc.c
+++ b/drivers/cisco/cisco-fpga-bmc.c
@@ -238,8 +238,6 @@ static struct i2c_driver cisco_fpga_bmc_driver = {
 module_i2c_driver(cisco_fpga_bmc_driver);
 
 MODULE_AUTHOR("Cisco Systems, Inc. <ospo-kmod@cisco.com>");
-MODULE_AUTHOR("Cisco Systems, Inc. <ospo-kmod@cisco.com>");
-MODULE_AUTHOR("Cisco Systems, Inc. <ospo-kmod@cisco.com>");
 MODULE_DESCRIPTION("Cisco BMC FPGA Driver");
 MODULE_LICENSE("GPL v2");
 MODULE_VERSION(DRIVER_VERSION);

--- a/drivers/cisco/cisco-fpga-msd.c
+++ b/drivers/cisco/cisco-fpga-msd.c
@@ -231,7 +231,6 @@ static struct platform_driver cisco_fpga_msd_driver = {
 module_platform_driver(cisco_fpga_msd_driver);
 
 MODULE_AUTHOR("Cisco Systems, Inc. <ospo-kmod@cisco.com>");
-MODULE_AUTHOR("Cisco Systems, Inc. <ospo-kmod@cisco.com>");
 MODULE_DESCRIPTION("Cisco FPGA ms_dev driver");
 MODULE_LICENSE("GPL v2");
 MODULE_ALIAS(PLATFORM_MODULE_PREFIX DRIVER_NAME);

--- a/drivers/cisco/reg_access.h
+++ b/drivers/cisco/reg_access.h
@@ -2,7 +2,7 @@
 /*
  * Cisco 8000 register access definitions
  *
- * Copyright (c) 2019 by Cisco Systems, Inc.
+ * Copyright (c) 2019, 2022 by Cisco Systems, Inc.
  * All rights reserved.
  */
 #ifndef _CISCO_REG_ACCESS_H


### PR DESCRIPTION
Remove duplicate MODULE_AUTHOR statements now
that they all say Cisco Systems, Inc.

Ensure all published files have current
copyright year